### PR TITLE
Cachefix

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -19,6 +19,9 @@ jobs:
         components: rustfmt, clippy
     - name: Rust | Cache
       uses: Swatinem/rust-cache@v2
+      with:
+        prefix-key: "rust-cache"
+        shared-key: "quick-tests"
     - name: Check Rust formatting
       run: cargo fmt -- --check
     - name: Check Rust code with Clippy
@@ -64,7 +67,8 @@ jobs:
     - name: Rust Cache
       uses: Swatinem/rust-cache@v2
       with:
-        key: deploy-cpp-cargo-target-${{ matrix.TARGET }}
+        prefix-key: "rust-cache"
+        shared-key: "build-cpp-${{ matrix.TARGET }}"
     - name: Rust Cross Build Cpp
       uses: actions-rs/cargo@v1
       with:


### PR DESCRIPTION
Cleanup on rust cache. Disabled sscache on maturin, due the strange  behaviors,
![image](https://github.com/bluerobotics/navigator-lib/assets/80598030/83962fe2-8aa5-4930-9f3c-60c358f3fc6a)

The nomenclature of tag follows:
rust-cache
-job
-matrix
-a hash of all Cargo.lock / Cargo.toml files found anywhere in the repository (if present).
-a hash of all rust-toolchain / rust-toolchain.toml files in the root of the repository (if present).

As we are using nightly channel the hash probably change everyday, maybe we can freeze it on a specific date?

please clean the cache directory if needed:

```#!/bin/bash
for counter in $(seq 1 30)
do
    cacheKeysForPR=$(gh actions-cache list -L 30 -R bluerobotics/navigator-lib | cut -f 1 )
    for cacheKey in $cacheKeysForPR
    do
        gh actions-cache delete $cacheKey --confirm -R bluerobotics/navigator-lib
        done
        echo "Done"
done
```


