### PR TITLE
rust-toolchain: lock the niglty version date, for cache's hash

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 # Necessary for cbindgen work with macro expansion
-channel = "nightly"
+channel = "nightly-2023-05-25"


### PR DESCRIPTION
Lock the nightly version, so cache will be reused if cargo-lock not change.