### PR TITLE
Upgrade: Add  pwm array methods, with dynamic lenght

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -332,5 +332,65 @@ export_cpy!(
                 .navigator
                 .set_pwm_channel_value(channel.into(), value)
         }
+
+        fn_c set_pwm_channels_value(channels: *const PwmChannel, value:u16, length: usize) {
+            let array_channels = unsafe {
+                assert!(!channels.is_null());
+                std::slice::from_raw_parts(channels, length)
+            };
+            for channel in array_channels.iter().take(length) {
+                NavigationManager::get_instance()
+                .lock()
+                .unwrap()
+                .as_mut()
+                .unwrap()
+                .navigator
+                .set_pwm_channel_value(channel.clone().into(), value);
+            }
+        }
+
+        fn_py set_pwm_channels_value(channels: Vec<PwmChannel>, value:u16) {
+            for i in 0..channels.len() {
+                NavigationManager::get_instance()
+                .lock()
+                .unwrap()
+                .as_mut()
+                .unwrap()
+                .navigator
+                .set_pwm_channel_value(channels[i].clone().into(), value);
+            }
+        }
+
+        fn_c set_pwm_channels_values(channels: *const PwmChannel, values : *const u16, length: usize) {
+            let array_channels = unsafe {
+                assert!(!channels.is_null());
+                std::slice::from_raw_parts(channels, length)
+            };
+            let array_values = unsafe {
+                assert!(!values.is_null());
+                std::slice::from_raw_parts(values, length)
+            };
+            for i in 0..length {
+                NavigationManager::get_instance()
+                .lock()
+                .unwrap()
+                .as_mut()
+                .unwrap()
+                .navigator
+                .set_pwm_channel_value(array_channels[i].clone().into(), array_values[i]);
+            }
+        }
+
+        fn_py set_pwm_channels_values(channels: Vec<PwmChannel>, values: Vec<u16>) {
+            for i in 0..channels.len() {
+                NavigationManager::get_instance()
+                .lock()
+                .unwrap()
+                .as_mut()
+                .unwrap()
+                .navigator
+                .set_pwm_channel_value(channels[i].clone().into(), values[i]);
+            }
+        }
     }
 );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@ impl From<PwmChannel> for navigator_rs::PwmChannel {
             PwmChannel::Ch14 => navigator_rs::PwmChannel::Ch14,
             PwmChannel::Ch15 => navigator_rs::PwmChannel::Ch15,
             PwmChannel::Ch16 => navigator_rs::PwmChannel::Ch16,
+            PwmChannel::All => navigator_rs::PwmChannel::All,
         }
     }
 }
@@ -123,6 +124,7 @@ export_cpy!(
             Ch14,
             Ch15,
             Ch16,
+            All,
         }
 
         struct AxisData {


### PR DESCRIPTION
With this PR, navigator Cpp and Python can set up PWM with dynamic arrays lenghts, as follows.

**Cpp:**
```cpp
  init();

  set_pwm_freq_hz(1000);

  PwmChannel channels[4] = {
      PwmChannel::Ch16,
      PwmChannel::Ch2,
      PwmChannel::Ch3,
      PwmChannel::Ch4,
  };

  uint16_t values[4] = {
      500,
      1000,
      1500,
      2000
  };

  set_pwm_channel_value(PwmChannel::All, 0);
  // OR
  set_pwm_channels_value( channels, 1000, 4);
  // OR
  set_pwm_channels_values(channels, values, 4);
  
  pwm_enable(true);
 
  ```
  
  
  **Python:**
  
```Python
    navigator.init()
    
    navigator.set_pwm_freq_hz(1000)
    
    navigator.set_pwm_channel_value(PwmChannel.Ch1, 2000)
    # OR
    navigator.set_pwm_channels_value([PwmChannel.Ch1, PwmChannel.Ch16], 1000)
    # OR
    navigator.set_pwm_channels_values([PwmChannel.Ch1, PwmChannel.Ch5], [1000, 500])

    navigator.pwm_enable(True)
```


Tested on current BlueOS, navigator hardware and osciloscope.