### PR TITLE
github: action: Move python documentation to its own folder

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -169,9 +169,12 @@ jobs:
         override: true
     - name: Build docs
       run: pip install hatch && hatch run dev:build-doc
+    # Move it to its own folder
+    - name: Move python documentation
+      run: mkdir -p pages/python && mv docs/_build/* pages/python/
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v3
       if: ${{ github.ref == 'refs/heads/master' }}
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./docs/_build
+        publish_dir: ./pages


### PR DESCRIPTION
The idea is to make the python documentation only available under /python, to have space for the cpp documentation once we have it 