### PR TITLE
Add auto version upgrade based on release-tag

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -49,8 +49,36 @@ jobs:
         check-path: 'examples/cpp/'
         exclude-regex: 'examples/cpp/build'
 
-  build-cpp:
+  version-manager:
     needs: [quick-tests]
+    runs-on: ubuntu-latest
+    outputs:
+      head_hash: ${{ steps.head-hash.outputs.head_hash }}
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Rust setup
+      uses: actions-rs/toolchain@v1.0.6
+      with:
+        toolchain: nightly
+        override: true
+    - name: Modify version if release-tag
+      if: startsWith(github.ref, 'refs/tags/')
+      run: |
+        cargo install cargo-bump --force \
+        && cargo bump ${{ github.ref_name }}
+    - name: Automatic commit for version upgrade
+      if: startsWith(github.ref, 'refs/tags/')
+      uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        branch: master
+        commit_message: "Cargo: Update the navigator-lib version to ${{ github.ref_name }}"
+    - name: Store the head actual hash
+      id: head-hash
+      run: echo "head_hash=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+  build-cpp:
+    needs: version-manager
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -63,7 +91,9 @@ jobs:
     steps:
     - name: Building ${{ matrix.TARGET }}
       run: echo "${{ matrix.TARGET }}"
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ needs.version-manager.outputs.head_hash }}
     - name: Rust Setup
       uses: actions-rs/toolchain@v1.0.1
       with:
@@ -94,7 +124,7 @@ jobs:
         path: dist
 
   build-python:
-    needs: [quick-tests]
+    needs: version-manager
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -103,6 +133,8 @@ jobs:
         libc: [auto, musllinux_1_1]
     steps:
     - uses: actions/checkout@v3
+      with:
+        ref: ${{ needs.version-manager.outputs.head_hash }}
     - uses: actions/setup-python@v4
       with:
         python-version: "3.9"
@@ -190,7 +222,7 @@ jobs:
         file_glob: true
 
   deploy-doc:
-    needs: quick-tests
+    needs: version-manager
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
This new job intendeds to manage the version automatically, based on the release tag.

It will run only after the quick tests (linter and building). 
If it's a release tag, it will auto-commit the version upgrade and generate a new hash for the next building jobs with a new version; 
otherwise, it will keep the same hash.

The hash is shared between jobs using the $GITHUB_OUTPUT.

normal:
![image](https://github.com/bluerobotics/navigator-lib/assets/80598030/1dac9483-2ed5-4c48-96f6-272982d48d80)
with tag:
![image](https://github.com/bluerobotics/navigator-lib/assets/80598030/f10b75ba-2b29-4ea7-b24e-7594f3945ce8)
commit:
![image](https://github.com/bluerobotics/navigator-lib/assets/80598030/f455f586-f63f-4a09-a5b2-fa254e6a6e11)
assets:
![image](https://github.com/bluerobotics/navigator-lib/assets/80598030/6b726e8e-bcc1-49b9-914a-ceb887986fe9)



