### PR TITLE
Fix: CI for MUSL targets and freeze navigator-rs version

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -166,8 +166,10 @@ jobs:
         githubToken: ${{ github.token }}
         install: |
           apk add py3-pip
-          pip3 install -U pip
         run: |
+          python3 -m venv ./venv
+          . ./venv/bin/activate
+          pip3 install -U pip
           pip3 install bluerobotics_navigator --no-index --find-links dist/ --force-reinstall
     - name: Upload wheels
       uses: actions/upload-artifact@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 cpy-binder = "1.0"
 libc = "0.2"
 pyo3 = { version = "0.18", features = ["extension-module", "abi3-py39"], optional = true }
-navigator-rs = { version = "0.3.0" }
+navigator-rs = { version = "=0.3.0" }
 rand = "0.8"
 lazy_static = "1.4.0"
 


### PR DESCRIPTION
Since alpine 3.19, python pip must use venv to install packages.

`Alpine 3.19`
Python’s package directory is now [marked](https://gitlab.alpinelinux.org/alpine/infra/aports/-/commit/6c2a300f6787544f3194e7f6cc19058baf9b7419) as [externally managed](https://packaging.python.org/en/latest/specifications/externally-managed-environments/); 
[Alpine-3.19.0-released](https://www.alpinelinux.org/posts/Alpine-3.19.0-released.html.)

navigator-rs:0.3.0
The release 0.3.1 breaked the api changing the `pwm_enable(bool)` to `set_pwm_enable() `and `get_pwm_enable()`
Related to this PR:

1. https://github.com/uraimo/run-on-arch-action/issues/143
2. https://github.com/bluerobotics/navigator-rs/releases/tag/0.3.1