### PR TITLE
Fix: examples: cpp: CMake Standalone fix aarch64 binaries

### DIFF
--- a/examples/cpp/CMakeLists_Standalone.txt
+++ b/examples/cpp/CMakeLists_Standalone.txt
@@ -29,7 +29,7 @@ ExternalProject_Add(
 if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "armv7")
     set(LIB_PATH_SUBDIR "armv7-unknown-linux-gnueabihf")
 elseif(${CMAKE_SYSTEM_PROCESSOR} MATCHES "armv8" OR ${CMAKE_SYSTEM_PROCESSOR} MATCHES "aarch64")
-    set(LIB_PATH_SUBDIR "aarch64-unknown-linux-gnueabihf")
+    set(LIB_PATH_SUBDIR "aarch64-unknown-linux-gnu")
 else()
     message(FATAL_ERROR "Unsupported architecture")
 endif()


### PR DESCRIPTION
From aarch64 device,
Details:
```
[ 81%] Built target navigator_zip
gmake[2]: *** No rule to make target 'navigator_zip_contents/aarch64-unknown-linux-gnueabihf/libbluerobotics_navigator.so', needed by 'simple'.  Stop.
gmake[2]: *** Waiting for unfinished jobs....
[ 90%] Building CXX object CMakeFiles/simple.dir/simple.cpp.o
gmake[1]: *** [CMakeFiles/Makefile2:111: CMakeFiles/simple.dir/all] Error 2
gmake: *** [Makefile:91: all] Error 2
```