### PR TITLE
ci: action: Fix C++ and Python builds

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -110,12 +110,12 @@ jobs:
       with:
         use-cross: true
         command: build
-        args: --verbose --release --target=${{ matrix.TARGET }} -Z unstable-options --out-dir output/
+        args: --verbose --release --target=${{ matrix.TARGET }}
     - name: Move to it's target
       run: |
         mkdir dist
         mkdir "dist/${{ matrix.TARGET }}"
-        mv output/* "dist/${{ matrix.TARGET }}"
+        mv target/${{ matrix.TARGET }}/release/*.so "dist/${{ matrix.TARGET }}"
         mv target/release/bindings.h dist/
     - name: Upload bin
       uses: actions/upload-artifact@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ cpy-binder = "1.0"
 libc = "0.2"
 pyo3 = { version = "0.18", features = ["extension-module", "abi3-py39"], optional = true }
 navigator-rs = { version = "0.6.0" }
+# 0.7.8 drops basepri on ARM Linux when HOST != TARGET
+cortex-m = "=0.7.7"
 rand = "0.8"
 lazy_static = "1.4.0"
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 # Necessary for cbindgen work with macro expansion
-channel = "nightly-2023-05-25"
+channel = "nightly-2026-08-20"


### PR DESCRIPTION
Nightly cargo dropped --out-dir, and the 2023 nightly cannot parse edition 2024.